### PR TITLE
feat: overhaul status chart design

### DIFF
--- a/components/chart-panel.tsx
+++ b/components/chart-panel.tsx
@@ -176,12 +176,11 @@ const ChartPanel: FC<ChartPanelProps> = ({ chartData, title, hideChart }) => {
               data={{
                 datasets: map(chartData, (data) => ({
                   data: slice(data.data, timePeriod),
-                  fill: false,
+                  fill: true,
                   label: data.name,
                   borderColor: `${data.color}`,
                   backgroundColor: `${data.color}54`,
                   pointStyle: false,
-                  borderWidth: 1.5,
                   tension: 0.15,
                 })),
                 labels: map(slice(chartData[0].labels, timePeriod), (date) =>

--- a/components/chart-panel.tsx
+++ b/components/chart-panel.tsx
@@ -8,17 +8,17 @@ import {
   PointElement,
   Title,
   Tooltip,
-} from 'chart.js';
-import day from 'dayjs';
-import { forEach, isEqual, map, size, slice, sum } from 'lodash';
-import { IIlumChart } from 'models/backend/ilum-models';
-import { useTheme } from 'next-themes';
-import { FC, useEffect, useState } from 'react';
-import { Line } from 'react-chartjs-2';
-import { isDark as isDarkTheme } from 'utils/theme-utils';
+} from "chart.js";
+import day from "dayjs";
+import { forEach, isEqual, map, size, slice, sum } from "lodash";
+import { IIlumChart } from "models/backend/ilum-models";
+import { useTheme } from "next-themes";
+import { FC, useEffect, useState } from "react";
+import { Line } from "react-chartjs-2";
+import { isDark as isDarkTheme } from "utils/theme-utils";
 
-import BasicPanel, { BasicPanelVariant } from './basic-panel';
-import Select from './select';
+import BasicPanel, { BasicPanelVariant } from "./basic-panel";
+import Select from "./select";
 
 ChartJS.register(
   CategoryScale,
@@ -44,13 +44,13 @@ interface ChartPanelProps {
 
 const statusToClass = {
   Stable:
-    'bg-[#16C172] text-lightText dark:text-lightText-darkMode dark:bg-[#16C172]/25 dark:border-2 dark:border-[#16C172]/60',
+    "bg-[#16C172] text-lightText dark:text-lightText-darkMode dark:bg-[#16C172]/25 dark:border-2 dark:border-[#16C172]/60",
   Unstable:
-    'bg-[#FC9E4F] text-lightText dark:text-lightText-darkMode dark:bg-[#FC9E4F]/25 dark:border-2 dark:border-[#FC9E4F]/60',
+    "bg-[#FC9E4F] text-lightText dark:text-lightText-darkMode dark:bg-[#FC9E4F]/25 dark:border-2 dark:border-[#FC9E4F]/60",
   Offline:
-    'bg-[#FF5964] text-lightText dark:text-lightText-darkMode dark:bg-[#FF5964]/25 dark:border-2 dark:border-[#FF5964]/60',
+    "bg-[#FF5964] text-lightText dark:text-lightText-darkMode dark:bg-[#FF5964]/25 dark:border-2 dark:border-[#FF5964]/60",
   Unknown:
-    'bg-[#3A2D32]/60 text-lightText dark:text-lightText-darkMode dark:bg-[#CC2936]/25 dark:border-2 dark:border-[#CC2936]/60',
+    "bg-[#3A2D32]/60 text-lightText dark:text-lightText-darkMode dark:bg-[#CC2936]/25 dark:border-2 dark:border-[#CC2936]/60",
 };
 
 const ChartPanel: FC<ChartPanelProps> = ({ chartData, title, hideChart }) => {
@@ -99,18 +99,18 @@ const ChartPanel: FC<ChartPanelProps> = ({ chartData, title, hideChart }) => {
                   }}
                   options={[
                     {
-                      id: '-144',
-                      title: 'Last 24 hours',
+                      id: "-144",
+                      title: "Last 24 hours",
                       selected: timePeriod === -144,
                     },
                     {
-                      id: '-1008',
-                      title: 'Last 7 days',
+                      id: "-1008",
+                      title: "Last 7 days",
                       selected: timePeriod === -1008,
                     },
                     {
-                      id: '-4032',
-                      title: 'Last 30 days',
+                      id: "-4032",
+                      title: "Last 30 days",
                       selected: timePeriod === -4032,
                     },
                   ]}
@@ -136,7 +136,7 @@ const ChartPanel: FC<ChartPanelProps> = ({ chartData, title, hideChart }) => {
                 responsive: true,
                 interaction: {
                   intersect: false,
-                  mode: 'index',
+                  mode: "index",
                 },
                 plugins: {
                   tooltip: {
@@ -149,9 +149,9 @@ const ChartPanel: FC<ChartPanelProps> = ({ chartData, title, hideChart }) => {
                   },
                   legend: {
                     labels: {
-                      color: 'blue',
+                      color: "blue",
                     },
-                    position: 'bottom',
+                    position: "bottom",
                     display: size(chartData) > 1,
                   },
                 },
@@ -176,13 +176,15 @@ const ChartPanel: FC<ChartPanelProps> = ({ chartData, title, hideChart }) => {
               data={{
                 datasets: map(chartData, (data) => ({
                   data: slice(data.data, timePeriod),
-                  fill: true,
+                  fill: false,
                   label: data.name,
                   borderColor: `${data.color}`,
                   backgroundColor: `${data.color}54`,
+                  pointStyle: false,
+                  borderWidth: 1.5,
                 })),
                 labels: map(slice(chartData[0].labels, timePeriod), (date) =>
-                  day(date).format(`DD MMM / hh:mm a`)
+                  day(date).format(`hh:mm a`)
                 ),
               }}
             />

--- a/components/chart-panel.tsx
+++ b/components/chart-panel.tsx
@@ -182,6 +182,7 @@ const ChartPanel: FC<ChartPanelProps> = ({ chartData, title, hideChart }) => {
                   backgroundColor: `${data.color}54`,
                   pointStyle: false,
                   borderWidth: 1.5,
+                  tension: 0.15,
                 })),
                 labels: map(slice(chartData[0].labels, timePeriod), (date) =>
                   day(date).format(`hh:mm a`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xp-dashboard",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xp-dashboard",
-      "version": "2.0.20",
+      "version": "2.0.21",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-regular-svg-icons": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xp-dashboard",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
I think these changes would make the status page chart a bit prettier.

Changes:
- set `pointStyle` to `false`
- change label date format to `hh:mm a` (I think the mention of the day is unnecessary and introduces clutter)
- set line `tension` to `0.15` for a smoother line
- set `fill` to `false`

Screenshot of reworked chart:
![image](https://github.com/xp-bot/dashboard/assets/40737538/2e765ea6-5b7f-439f-a439-26465d588266)
